### PR TITLE
Fix: Resolve index error in options when using outdated configurations

### DIFF
--- a/custom_components/huggingchat_conversation/config_flow.py
+++ b/custom_components/huggingchat_conversation/config_flow.py
@@ -174,8 +174,8 @@ async def huggingchat_config_option_schema(
         _LOGGER.error(err)
         models = [{"label": "An error has occurred", "value": "0"}]
 
-    if not options:
-        options = DEFAULT_OPTIONS
+    options = {**DEFAULT_OPTIONS, **options}
+
     return {
         vol.Optional(
             CONF_CHAT_MODEL,


### PR DESCRIPTION
This commit addresses an index error in the options caused by outdated configurations from previous updates. This fix ensures compatibility with Conversations created using previous versions by merging options with DEFAULT_OPTIONS.