### PR TITLE
fix Prompt

### DIFF
--- a/custom_components/huggingchat_conversation/__init__.py
+++ b/custom_components/huggingchat_conversation/__init__.py
@@ -23,7 +23,6 @@ from .const import (
     CONF_WEB_SEARCH,
     CONF_WEB_SEARCH_ENGINE,
     CONF_WEB_SEARCH_PROMPT,
-    DEFAULT_ASSISTANT_ID,
     DEFAULT_ASSISTANTS,
     DEFAULT_CHAT_MODEL,
     DEFAULT_PROMPT,
@@ -85,7 +84,7 @@ class HuggingChatAgent(conversation.AbstractConversationAgent):
             CONF_ASSISTANTS, DEFAULT_ASSISTANTS
         )
         assistant_id = self.entry.options.get(
-            CONF_ASSISTANT_ID, DEFAULT_ASSISTANT_ID
+            CONF_ASSISTANT_ID
         )
         web_search = self.entry.options.get(CONF_WEB_SEARCH, DEFAULT_WEB_SEARCH)
         web_search_engine = self.entry.options.get(

--- a/custom_components/huggingchat_conversation/config_flow.py
+++ b/custom_components/huggingchat_conversation/config_flow.py
@@ -32,7 +32,6 @@ from .const import (
     CONF_WEB_SEARCH,
     CONF_WEB_SEARCH_ENGINE,
     CONF_WEB_SEARCH_PROMPT,
-    DEFAULT_ASSISTANT_ID,
     DEFAULT_ASSISTANTS,
     DEFAULT_CHAT_MODEL,
     DEFAULT_EMAIL,
@@ -64,7 +63,7 @@ DEFAULT_OPTIONS = types.MappingProxyType(
         CONF_CHAT_MODEL: DEFAULT_CHAT_MODEL,
         CONF_PROMPT: DEFAULT_PROMPT,
         CONF_ASSISTANTS: DEFAULT_ASSISTANTS,
-        CONF_ASSISTANT_ID: DEFAULT_ASSISTANT_ID,
+        CONF_ASSISTANT_ID: None,
         CONF_WEB_SEARCH: DEFAULT_WEB_SEARCH,
         CONF_WEB_SEARCH_ENGINE: DEFAULT_WEB_SEARCH_ENGINE,
         CONF_WEB_SEARCH_PROMPT: DEFAULT_WEB_SEARCH_PROMPT,
@@ -189,7 +188,6 @@ async def huggingchat_config_option_schema(
         vol.Optional(
             CONF_ASSISTANT_ID,
             description={"suggested_value": options[CONF_ASSISTANT_ID]},
-            default=DEFAULT_ASSISTANT_ID,
         ): str,
         vol.Optional(
             CONF_WEB_SEARCH,

--- a/custom_components/huggingchat_conversation/const.py
+++ b/custom_components/huggingchat_conversation/const.py
@@ -51,7 +51,6 @@ If the user wants to control a device, reject the request and suggest using the 
 """
 DEFAULT_ASSISTANTS = False
 CONF_ASSISTANTS = "enable_assistants"
-DEFAULT_ASSISTANT_ID = "65bd6d583140495b7e30f744"
 CONF_ASSISTANT_ID = "assistant_id"
 DEFAULT_WEB_SEARCH = False
 CONF_WEB_SEARCH = "web_search"


### PR DESCRIPTION
With an assistant_id the prompt will not be used. So i removed the default. Now you can let it empty in config and the Prompt can be used.